### PR TITLE
Configure plugins on top level in sample .babelrc

### DIFF
--- a/docs/Guides-BabelPlugin.md
+++ b/docs/Guides-BabelPlugin.md
@@ -40,8 +40,10 @@ The `babel-relay-plugin` must run before the `react-native` Babel preset. Thus, 
 ```javascript
 {
   "passPerPreset": true,
+  "plugins": [
+    "./plugins/babelRelayPlugin"
+  ],
   "presets": [
-    {"plugins": ["./plugins/babelRelayPlugin"]},
     "react-native"
   ]
 }


### PR DESCRIPTION
The plugins config in the example `.babelrc` must be on the top level, not inside the presets array.